### PR TITLE
chore: add simple livez endpoint

### DIFF
--- a/cmd/livez_handler_test.go
+++ b/cmd/livez_handler_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("livezHandler", func() {
+	var (
+		recorder *httptest.ResponseRecorder
+		request  *http.Request
+	)
+
+	BeforeEach(func() {
+		recorder = httptest.NewRecorder()
+		var err error
+		request, err = http.NewRequest("GET", "/livez", nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when called", func() {
+		It("should return a 200 OK status", func() {
+			livezHandler(recorder, request)
+			Expect(recorder.Code).To(Equal(http.StatusOK))
+		})
+
+		It("should return 'alive' in the response body", func() {
+			livezHandler(recorder, request)
+			Expect(recorder.Body.String()).To(ContainSubstring("alive"))
+		})
+
+		It("should handle different HTTP methods", func() {
+			methods := []string{"GET", "POST", "HEAD", "PUT", "DELETE"}
+			for _, method := range methods {
+				req, err := http.NewRequest(method, "/livez", nil)
+				Expect(err).NotTo(HaveOccurred())
+				rec := httptest.NewRecorder()
+
+				livezHandler(rec, req)
+				Expect(rec.Code).To(Equal(http.StatusOK), "Method %s should return 200", method)
+				Expect(rec.Body.String()).To(ContainSubstring("alive"), "Method %s should return 'alive'", method)
+			}
+		})
+	})
+
+	Context("when handling concurrent requests", func() {
+		It("should handle multiple simultaneous requests without issues", func() {
+			const numRequests = 10
+			responses := make([]*httptest.ResponseRecorder, numRequests)
+
+			// Launch multiple concurrent requests
+			done := make(chan bool, numRequests)
+			for i := 0; i < numRequests; i++ {
+				go func(index int) {
+					defer func() { done <- true }()
+					req, err := http.NewRequest("GET", "/livez", nil)
+					Expect(err).NotTo(HaveOccurred())
+					responses[index] = httptest.NewRecorder()
+					livezHandler(responses[index], req)
+				}(i)
+			}
+
+			// Wait for all requests to complete
+			for i := 0; i < numRequests; i++ {
+				<-done
+			}
+
+			// Verify all responses are correct
+			for i, response := range responses {
+				Expect(response.Code).To(Equal(http.StatusOK), "Request %d should return 200", i)
+				Expect(response.Body.String()).To(ContainSubstring("alive"), "Request %d should return 'alive'", i)
+			}
+		})
+	})
+})

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -158,6 +158,13 @@ func healthzHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// livezHandler performs a simple check to see if the process is running.
+// This can be used for a Kubernetes livenessProbe to ensure the HTTP server is responsive.
+func livezHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintln(w, "alive")
+}
+
 func main() {
 	log.Println("Starting Smee instrumentation sidecar...")
 
@@ -189,8 +196,9 @@ func main() {
 	mgmtMux := http.NewServeMux()
 	mgmtMux.Handle("/metrics", promhttp.Handler())
 	mgmtMux.HandleFunc("/healthz", healthzHandler)
+	mgmtMux.HandleFunc("/livez", livezHandler)
 	go func() {
-		log.Println("Management server (metrics, healthz) listening on :9100")
+		log.Println("Management server (metrics, healthz, livez) listening on :9100")
 		if err := http.ListenAndServe(":9100", mgmtMux); err != nil {
 			log.Fatalf("FATAL: Management server failed: %v", err)
 		}

--- a/test/config/system-test-setup.yaml
+++ b/test/config/system-test-setup.yaml
@@ -99,7 +99,7 @@ spec:
               value: "http://smee-server-service.default.svc.cluster.local/systemcheckchannel"
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /livez
               port: 9100
             initialDelaySeconds: 5
             periodSeconds: 3


### PR DESCRIPTION
This will be used for liveness probe on the sidecar and will make sure that the sidecar is accepting calls, rather than verifying that the e2e check is passing.

This should address an issue where both containers crashloop at the same time, which caused the check to fail constantly.