### PR TITLE
fix: sidecar fails to rewrite scripts

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -104,6 +104,15 @@ func writeScriptsToVolume(sharedPath string) error {
 
 	for filename, content := range scripts {
 		scriptPath := filepath.Join(sharedPath, filename)
+
+		// Check if file exists and make it writable before overwriting
+		// This handles container restarts where the volume persists with read-only files
+		if _, err := os.Stat(scriptPath); err == nil {
+			if err := os.Chmod(scriptPath, 0755); err != nil {
+				return fmt.Errorf("failed to make %s writable: %v", filename, err)
+			}
+		}
+
 		if err := os.WriteFile(scriptPath, content, 0755); err != nil {
 			return fmt.Errorf("failed to write %s: %v", filename, err)
 		}


### PR DESCRIPTION
The sidecar is writing the scripts to the shared volume on startup and it's making them read-only.

We didn't take into account the scenario in which the sidecar crashes and the shared volume persisted. In this case, it will fail to overwrite the read-only scripts.

This change should address the issue.