### PR TITLE
fix: drain request body to allow connection reuse

### DIFF
--- a/test/config/system-test-setup.yaml
+++ b/test/config/system-test-setup.yaml
@@ -56,7 +56,7 @@ spec:
           emptyDir: {}
       containers:
         - name: gosmee-client
-          image: ghcr.io/chmouel/gosmee:v0.26.0
+          image: ghcr.io/chmouel/gosmee:v0.26.1
           args:
             - client
             - http://smee-server-service.default.svc.cluster.local/systemcheckchannel


### PR DESCRIPTION
We were missing the part of draining the request body, which did not allow the connection to be reused.