### PR TITLE
fix: close connection for health checks

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -125,6 +125,9 @@ func forwardHandler(w http.ResponseWriter, r *http.Request) {
 		// Always drain request body to prevent connection reuse issues
 		_, _ = io.Copy(io.Discard, r.Body)
 
+		// Force connection closure for health checks to prevent connection pooling
+		w.Header().Set("Connection", "close")
+
 		mutex.Lock()
 		resultChan, exists := healthChecks[healthCheckID]
 		mutex.Unlock()


### PR DESCRIPTION
Health checks are accumulating connections as we expect their connection to be reused but in reality the smee client creates a new one for each health check event.

This fix force connection to be closed for health check events.