### PR TITLE
Add AGENTS.md and CI validation for line count

### DIFF
--- a/.github/workflows/unit-tests-and-linting.yaml
+++ b/.github/workflows/unit-tests-and-linting.yaml
@@ -1,4 +1,4 @@
-name: Go CI
+name: Unit Tests & Linting
 
 on:
   push:
@@ -35,3 +35,13 @@ jobs:
       - name: Test health check scripts
         run: |
           test/scripts/test-health-scripts.sh
+
+      - name: Validate AGENTS.md line count
+        run: |
+          MAX_LINES=300
+          ACTUAL_LINES=$(wc -l < AGENTS.md)
+          if [ "$ACTUAL_LINES" -gt "$MAX_LINES" ]; then
+            echo "::error::AGENTS.md has $ACTUAL_LINES lines, exceeding the $MAX_LINES line limit"
+            exit 1
+          fi
+          echo "AGENTS.md has $ACTUAL_LINES lines (limit: $MAX_LINES)"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+## Project Overview
+
+smee-sidecar is a Go sidecar container for Smee deployments. It provides health
+checking and webhook event relay between a Smee client and a downstream service
+(e.g. Pipelines as Code). It runs inside a Kubernetes pod alongside a Smee client.
+
+## Code Structure
+
+All application code lives in `cmd/main.go` (single-file, single package `main`).
+Shell scripts in `cmd/scripts/` are embedded via `go:embed` directives.
+
+- `cmd/main.go` -- Main application: HTTP handlers, health checker, metrics
+- `cmd/scripts/` -- Embedded health check scripts for Kubernetes liveness probes
+- `test/` -- Integration test infrastructure
+
+## Key Concepts
+
+The sidecar runs two HTTP servers:
+- **Relay server** (`:8080`): Receives events from the Smee client. Health check
+  events (identified by `X-Health-Check-ID` header) are consumed internally.
+  All other events are reverse-proxied to the downstream service.
+- **Management server** (`:9100`): Prometheus metrics at `/metrics`.
+
+A background goroutine (`runHealthChecker`) periodically sends health check events
+to the Smee server channel, waits for them to round-trip back through the client,
+and writes results to a shared file for Kubernetes liveness probes.
+
+## Build and Test
+
+```bash
+# Run unit tests (must be serial -- tests share global state)
+go test -p 1 ./... -v
+
+# Build container
+podman build -t smee-sidecar:latest .
+```
+
+Tests use Ginkgo v2 / Gomega. Test files are in `cmd/` alongside `main.go`.
+Tests reset global state in `BeforeEach` blocks -- do not run tests in parallel.
+
+## Environment Variables
+
+Required: `DOWNSTREAM_SERVICE_URL`, `SMEE_CHANNEL_URL`
+Optional: `HEALTH_CHECK_INTERVAL_SECONDS` (default 30),
+`HEALTH_CHECK_TIMEOUT_SECONDS` (default 20), `SHARED_VOLUME_PATH` (default /shared),
+`HEALTH_FILE_PATH`, `INSECURE_SKIP_VERIFY`, `ENABLE_PPROF`
+
+## Conventions
+
+- All Go code is in the `cmd/` directory with `package main`
+- Use `podman` instead of `docker` for container operations
+- Health status files are written atomically (write to `.tmp`, then rename)
+- Prometheus metrics: `smee_events_relayed_total` (counter), `health_check` (gauge)
+- `sync.Once` is used for lazy initialization of HTTP client and reverse proxy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
AI agents interacting with the repo lack context about the project structure, build process, and conventions. An AGENTS.md file provides this context concisely, and a CLAUDE.md symlink ensures Claude-based tools pick it up automatically.

The CI workflow is renamed from "Go CI" to "Unit Tests & Linting" to reflect its broader scope now that it includes non-Go checks.

Ref: https://redhat.atlassian.net/browse/KFLUXVNGD-976

Assisted-by: Claude claude-opus-4-6

## AGENTS.md Effectiveness Experiment

### Setup

Two AI agents were given the same task: *"How would you add a Prometheus histogram
that tracks health check round-trip latency? Describe where to make changes, show the
code, and explain how to test and build."*

- **Agent A** received the AGENTS.md content as upfront context
- **Agent B** received no context and worked in a separate copy of the repo where
  AGENTS.md did not exist on disk

Both agents were instructed to track every exploration step and to not modify files.

### Quantitative Results

| Metric              | Agent A (with AGENTS.md) | Agent B (without AGENTS.md) |
|---------------------|-------------------------:|----------------------------:|
| Exploration steps   |                        2 |                          12 |
| Tool uses           |                        9 |                          12 |
| Total tokens        |                   45,639 |                      47,266 |
| Duration            |                    62.8s |                       70.3s |

Agent A needed only **2 exploration steps** (reading `cmd/main.go` and
`cmd/health_checker_test.go`) to find all the information it needed. Agent B
required **12 steps**, spending its extra effort on orientation: listing directories,
reading `go.mod`, `README.md`, `Dockerfile`, CI workflow, and shell scripts before
reaching the same relevant files.

### Qualitative Differences

**Navigation efficiency**: Agent A went straight to `cmd/main.go` and
`cmd/health_checker_test.go` as its first two reads -- the only files needed to
answer the question. Agent B started with `find`, `ls`, then read `go.mod`,
`Dockerfile`, CI workflow, shell scripts, and all four test files before arriving
at its answer.

**Convention adherence**: Agent A used `podman` (not `docker`) for the build command
and `go test -p 1` for serial test execution from the start -- both conventions
documented in AGENTS.md. Agent B used `docker build` in its initial answer, missing
the project's `podman` convention entirely since it was not documented anywhere in
the codebase. Agent B only discovered the `-p 1` test flag by reading the CI workflow
file.

**Code quality**: Both agents proposed correct, equivalent implementations: histogram
declaration, `Observe()` call after the existing `time.Since()` computation in
`performHealthCheck`, `BeforeEach` metric re-creation in tests, and
`testutil.ToFloat64` / `testutil.CollectAndCount` for assertions. The AGENTS.md
context improved efficiency without sacrificing output quality.

### Conclusion

The AGENTS.md file reduced exploration from 12 steps to 2 (83% reduction) and
ensured immediate adherence to repo conventions. Without it, Agent B made a convention
error (`docker` instead of `podman`) that it had no way to discover from the codebase
alone. Both agents reached the same code quality, but Agent A got there with fewer
tool calls, less token usage, and less wall-clock time.