### PR TITLE
fix: renovate config for go lint version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,8 @@
             "matchStrings": ["^(?<currentValue>v?\\d+\\.\\d+\\.\\d+)\\s*$"],
             "datasourceTemplate": "github-releases",
             "depNameTemplate": "golangci/golangci-lint",
-            "extractVersionTemplate": "^v?(?<version>.*)$"
+            "extractVersionTemplate": "^v?(?<version>.*)$",
+            "autoReplaceStringTemplate": "v{{{newValue}}}"
         }
     ],
     "kubernetes": {


### PR DESCRIPTION
The config was broken, causing the updated version to be referenced without a prefixing "v".

Assisted-by: Cursor