### PR TITLE
renovate: disable indirect Go module updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,13 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "packageRules": [
+        {
+            "description": "Disable Renovate updates for indirect Go dependencies since they are resolved by go mod tidy based on direct dependency requirements",
+            "matchManagers": ["gomod"],
+            "matchDepTypes": ["indirect"],
+            "enabled": false
+        }
+    ],
     "prConcurrentLimit": 0,
     "customManagers": [
         {


### PR DESCRIPTION
## Summary
- Disable Renovate updates for indirect-only Go module dependencies via `gomod.packageRules`
- Indirect deps are resolved by `go mod tidy` when direct dependencies change

## Test plan
- [ ] Verify Renovate config is valid JSON
- [ ] Confirm MintMaker/Renovate no longer opens PRs for indirect-only gomod updates

Made with [Cursor](https://cursor.com)