### PR TITLE
Update codecov.yml: add ignore patterns for non-code files

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,15 @@
 codecov:
   require_ci_to_pass: false
 
+ignore:
+  - ".agents/**"
+  - ".claude/**"
+  - ".cursor/**"
+  - "skills/**"
+  - "docs/**"
+  - "*.md"
+  - "*.toml"
+
 coverage:
   status:
     project:


### PR DESCRIPTION
## Summary

Adds ignore patterns to `codecov.yml` for non-executable files that inflate the coverage denominator:

- `.agents/**` — AI agent configurations
- `.claude/**` — Claude AI workspace settings
- `.cursor/**` — Cursor AI settings
- `skills/**` — AI skill definitions
- `docs/**` — Documentation files
- `*.md` — Markdown files
- `*.toml` — TOML configuration files

Existing config (flags with vendor path exclusion) is preserved.

## Why

Non-executable files are counted as "uncovered lines" by Codecov, dragging down patch coverage even though they can't be tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)