### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/differential-shellcheck.yaml
+++ b/.github/workflows/differential-shellcheck.yaml
@@ -22,13 +22,13 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           # Differential ShellCheck requires full git history
           fetch-depth: 0
 
       - id: DiffShellCheck
         name: Differential ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@d965e66ec0b3b2f821f75c8eff9b12442d9a7d1e # v5
+        uses: redhat-plumbers-in-action/differential-shellcheck@d965e66ec0b3b2f821f75c8eff9b12442d9a7d1e  # v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -16,11 +16,11 @@ jobs:
       go: ${{ steps.changed-files.outputs.any_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
       - name: Check for changes
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         id: changed-files
         with:
           files: |
@@ -38,14 +38,14 @@ jobs:
     if: needs.check-changes.outputs.go == 'true'
     steps:
       - name: Clone the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Setup Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version-file: go.mod
 
       - name: Run linter
-        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
+        uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a  # v9.3.0
         with:
           version-file: .golangci-lint-version

--- a/.github/workflows/system-test.yaml
+++ b/.github/workflows/system-test.yaml
@@ -14,15 +14,15 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version-file: go.mod
 
       - name: Create k8s Kind Cluster
-        uses: helm/kind-action@v1.14.0
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc  # v1.14.0
         with:
           cluster_name: kind
 

--- a/.github/workflows/unit-tests-and-linting.yaml
+++ b/.github/workflows/unit-tests-and-linting.yaml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Set up Go
-        uses: actions/setup-go@v7
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7
         with:
           go-version-file: go.mod
 
@@ -25,7 +25,7 @@ jobs:
         run: go test -p 1 -coverprofile=coverage.out -covermode=atomic ./... -v
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v7
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit-tests

--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -16,11 +16,11 @@ jobs:
       yaml: ${{ steps.changed-files.outputs.any_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
       - name: Check for changes
-        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96  # v47.0.6
         id: changed-files
         with:
           files: |
@@ -36,7 +36,7 @@ jobs:
     if: needs.check-changes.outputs.yaml == 'true'
     steps:
       - name: Clone the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Run yamllint
-        uses: frenck/action-yamllint@34b4bbcaeabedcfefad6adea8c5bbc42af0e2d47 # v1
+        uses: frenck/action-yamllint@34b4bbcaeabedcfefad6adea8c5bbc42af0e2d47  # v1


### PR DESCRIPTION
## Summary
- Pin GitHub Actions in workflows to full 40-character commit SHAs with inline version comments so Renovate can keep updating them.
- Leave org reusable `fullsend` workflow refs on `@main` unchanged where present.

## Test plan
- [ ] Workflows that use the pinned actions still pass CI
- [ ] YAML lint (if present) is clean for comment spacing before `#`

Made with [Cursor](https://cursor.com)